### PR TITLE
Add version number into SOA-Precheck.json output

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1821,6 +1821,7 @@ Function Install-SOAPrerequisites
 
     New-Object -TypeName PSObject -Property @{
         Date=$(Get-Date)
+	Version="0.4.5"
         Results=$CheckResults
         ModulesOK=$Modules_OK
         ModulesError=$Modules_Error


### PR DESCRIPTION
This is being done so that the SOA engineer can see which version of the prerequisite script has been run.