### PR TITLE
Scotbue 1949

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -197,7 +197,7 @@ Function Install-ExchangeModule {
     Write-Host "Depending on your AuthentiCode settings, you may see an 'Application Install - Security Warning'" -ForegroundColor Yellow
     Write-Host "Verify the publisher is Microsoft Corporation and Ensure you select 'Install'" -ForegroundColor Yellow
 
-    Invoke-Expression "rundll32.exe dfshim.dll,ShOpenVerbApplication http://aka.ms/exomodule"
+    Invoke-Expression "rundll32.exe dfshim.dll,ShOpenVerbApplication http://aka.ms/exopsmodule"
 
     $Installing = $True
     $Installed = $False

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -197,7 +197,7 @@ Function Install-ExchangeModule {
     Write-Host "Depending on your AuthentiCode settings, you may see an 'Application Install - Security Warning'" -ForegroundColor Yellow
     Write-Host "Verify the publisher is Microsoft Corporation and Ensure you select 'Install'" -ForegroundColor Yellow
 
-    Invoke-Expression "rundll32.exe dfshim.dll,ShOpenVerbApplication http://aka.ms/exopsmodule"
+    Invoke-Expression "rundll32.exe dfshim.dll,ShOpenVerbApplication https://aka.ms/exopsmodule"
 
     $Installing = $True
     $Installed = $False

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -197,7 +197,7 @@ Function Install-ExchangeModule {
     Write-Host "Depending on your AuthentiCode settings, you may see an 'Application Install - Security Warning'" -ForegroundColor Yellow
     Write-Host "Verify the publisher is Microsoft Corporation and Ensure you select 'Install'" -ForegroundColor Yellow
 
-    Invoke-Expression "rundll32.exe dfshim.dll,ShOpenVerbApplication http://aka.ms/exopspreview"
+    Invoke-Expression "rundll32.exe dfshim.dll,ShOpenVerbApplication http://aka.ms/exomodule"
 
     $Installing = $True
     $Installed = $False


### PR DESCRIPTION
Added optional switch (UseEXOv2Module) to install the v2 module instead of v1.  Also:

- Restructured the parameters so they can be used in multiple parameter sets
- Added NoVersionCheck switch (same as in the collection script) to not check for a newer version of the module (helpful when testing a branch that might not be from the latest)
- Changed the version written to the output json file from a hard-coded string to whatever version of the module is currently loaded