### PR TITLE
Hotfix for Teams / Skype PS issues

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -966,7 +966,7 @@ Function Test-Connections {
     }
 
     <#
-    
+    connect
         SharePoint
     
     #>
@@ -1003,14 +1003,11 @@ Function Test-Connections {
         # Reset vars
         $Connect = $False; $ConnectError = $Null; $Command = $False; $CommandError = $Null
 
-        Write-Host "$(Get-Date) Connecting to Skype (via Microsoft Teams module)..."
+        Write-Host "$(Get-Date) Connecting to Teams (including Skype for Business Online)..."
         $SfBOAdminDomain = (Get-AzureADTenantDetail | Select-Object -ExpandProperty VerifiedDomains | Where-Object { $_.Initial }).Name
-        # Explicitly reference New-CsOnlineSession in the Teams modules to ensure the cmdlet in the SfBo module is not used
-        $SfBOSession = MicrosoftTeams\New-CsOnlineSession -OverrideAdminDomain $SfBOAdminDomain -ErrorVariable $ConnectError -ErrorAction:SilentlyContinue -SessionOption $RPSProxySetting
+        Connect-MicrosoftTeams -TenantId $SfBOAdminDomain -ErrorVariable $ConnectError -ErrorAction:SilentlyContinue
 
-        If($SfBOSession.State -eq "Opened") { $Connect = $True } Else { $Connect = $False }
-
-        Import-PSSession -Session $SfBOSession -AllowClobber | Out-Null
+   	If((Get-PSSession | Where-Object {$_.ComputerName -like "*teams.microsoft.com"}).State -eq "Opened") { $Connect = $True } Else { $Connect = $False }
 
         # Run test command
         If(Get-Command "Get-CSTenant") {

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1006,9 +1006,7 @@ Function Test-Connections {
         $SfBOAdminDomain = (Get-AzureADTenantDetail | Select-Object -ExpandProperty VerifiedDomains | Where-Object { $_.Initial }).Name
         Connect-MicrosoftTeams -TenantId $SfBOAdminDomain -ErrorVariable $ConnectError -ErrorAction:SilentlyContinue
 
-   	If((Get-PSSession | Where-Object {$_.ComputerName -like "*teams.microsoft.com"}).State -eq "Opened") { $Connect = $True } Else { $Connect = $False }
-
-        # Run test command
+   	# Run test command
         If(Get-Command "Get-CSTenant") {
             If((Get-CSTenant).TenantID) {
                 $Command = $True
@@ -1018,6 +1016,9 @@ Function Test-Connections {
         } Else {
             $Command = $False
         }
+	
+	# Check for connection after command test because remote session is not established until after a cmdlet that needs it is run
+	If((Get-PSSession | Where-Object {$_.ComputerName -like "*teams.microsoft.com"}).State -eq "Opened") { $Connect = $True } Else { $Connect = $False }
 
         $Connections += New-Object -TypeName PSObject -Property @{
             Name="Teams"

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -966,7 +966,6 @@ Function Test-Connections {
     }
 
     <#
-    connect
         SharePoint
     
     #>


### PR DESCRIPTION
Multiple customers are seeing issues with Teams connections due to some changes to the way that Skype for Business Online is connected to. Code has been modified to connect directly to Teams, and this should also make the CS cmdlets available.