### PR TITLE
Change PP test command

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1317,25 +1317,24 @@ Function Test-Connections {
 
             Write-Host "$(Get-Date) Connecting to Power Apps..."
             switch ($O365EnvironmentName) {
-                "Commercial"   {$PAConnection = Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError | Out-Null;break}
-                "USGovGCC"     {$PAConnection = Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError -Endpoint usgov | Out-Null;break}
-                "USGovGCCHigh" {$PAConnection = Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError -Endpoint usgovhigh | Out-Null;break}
-                "USGovDoD"     {$PAConnection = Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError -Endpoint dod | Out-Null;break}
+                "Commercial"   {Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError | Out-Null;break}
+                "USGovGCC"     {Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError -Endpoint usgov | Out-Null;break}
+                "USGovGCCHigh" {Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError -Endpoint usgovhigh | Out-Null;break}
+                "USGovDoD"     {Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError -Endpoint dod | Out-Null;break}
                 #"Germany"     {"Power Platform is not available in Germany" | Out-Null;break}
-                "China"        {$PAConnection = Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError -Endpoint china | Out-Null}
+                "China"        {Add-PowerAppsAccount -ErrorAction:SilentlyContinue -ErrorVariable ConnectError -Endpoint china | Out-Null}
             }
 
             # If no error, try test command
-            if ($ConnectError) { $Connect = $False; $Command = $False} Else { 
+            if ($ConnectError) { $Connect = $False; $Command = ""} Else { 
                 $Connect = $True 
-                # Test command can be run by non-admin without error, but no data is returned
-                # Check if data is returned to determine if an admin connected
-                $cmdResult = Get-AdminPowerAppEnvironment -ErrorAction SilentlyContinue -ErrorVariable CommandError
+                # Check if data is returned
+                $cmdResult = Get-TenantSettings -ErrorAction SilentlyContinue -ErrorVariable CommandError
                 if ($CommandError -or -not($cmdResult)) {
                     # Cmdlet may not return data if no PA license assigned or user has not been to PPAC before
                     Write-Warning -Message "No data was returned when running the test command. This can occur if the admin has never used the Power Platform Admin Center (PPAC). Please go to https://aka.ms/ppac and sign in as the Global administrator or Dynamics 365 administrator account you used to connect to Power Platform in PowerShell.  Then return here to continue."
                     Read-Host -Prompt "Press Enter after you have navigated to PPAC and signed in with the adminstrator account used above to connect to Power Platform in PowerShell."
-                    $cmdResult = Get-AdminPowerAppEnvironment -ErrorAction SilentlyContinue -ErrorVariable CommandError
+                    $cmdResult = Get-TenantSettings -ErrorAction SilentlyContinue -ErrorVariable CommandError
                     if ($CommandError -or -not($cmdResult)) {
                         $Command = $False
                     }


### PR DESCRIPTION
Changed test command for Power Platform to use Get-TenantSettings because Get-AdminPowerAppEnvironment doesn't return anything in some environments, believed to all be GCC, for some reason.  Because standard users can run Get-TenantSettings and get the needed data, it is sufficient to test with this regardless of the signed in account being a service admin or standard user.