### PR TITLE
Add M365 G5 Security SKU for ATP P2

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -831,7 +831,7 @@ function Get-LicenseStatus {
     param ($LicenseType)
     if ($LicenseType -eq 'ATPP2') {
         # SKUs that start with strings include Defender P2 to be able to use the Defender API
-        $targetSkus = @('ENTERPRISEPREMIUM','SPE_E5','M365EDU_A5','IDENTITY_THREAT_PROTECTION','THREAT_INTELLIGENCE','M365_SECURITY_COMPLIANCE')
+        $targetSkus = @('ENTERPRISEPREMIUM','SPE_E5','M365EDU_A5','IDENTITY_THREAT_PROTECTION','THREAT_INTELLIGENCE','M365_SECURITY_COMPLIANCE','Microsoft_365 G5_Security')
     }
     else {
         Write-Error -Message "$(Get-Date) Invalid license type specified"


### PR DESCRIPTION
Updated listed of SKUs that include ATP P2 for using Defender API.