### PR TITLE
Add retry and sleep logic to MSAL access token

### DIFF
--- a/SOA.psd1
+++ b/SOA.psd1
@@ -87,7 +87,7 @@ PowerShellVersion = '5.1'
 NestedModules = @("SOA-Prerequisites.psm1","SOA-ImportExport.psm1")
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @("Install-SOAPrerequisites","Test-SOAApplication","Invoke-SOAVersionCheck","Export-SOARPS","Invoke-WinRMBasicCheck","Get-LicenseStatus")
+FunctionsToExport = @("Install-SOAPrerequisites","Test-SOAApplication","Invoke-SOAVersionCheck","Export-SOARPS","Invoke-WinRMBasicCheck","Get-LicenseStatus","Import-MSAL","Get-MSALAccessToken")
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
Currently the script needs to wait for passwords to settle before attempting to retrieve an Access Token, and it doesn't retry if there is a failure. Creating a retry loop so that we can reduce the amount of waiting time for a token.