### PR TITLE
Change method to detect SPO admin url

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -103,7 +103,7 @@ function Get-SPOTenantName
     
     #>
     
-    $domain = ((Get-AcceptedDomain | Where-Object {$_.InitialDomain -eq $True}).DomainName)
+    $domain = ((Get-AzureADDomain | Where-Object {$_.IsInitial -eq $True}).Name)
     return ($domain -Split ".onmicrosoft.com")[0]
 
 }

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -102,9 +102,9 @@ function Get-SPOTenantName
         Used to determine what the SharePoint Tenant Name is during connection tests
     
     #>
-
-    $sku = (Get-MsolAccountSku -ErrorAction:SilentlyContinue)[0]
-    return $sku.AccountName
+    
+    $domain = ((Get-AcceptedDomain | Where-Object {$_.InitialDomain -eq $True}).DomainName)
+    return ($domain -Split ".onmicrosoft.com")[0]
 
 }
 


### PR DESCRIPTION
Replacing usage of Get-MsolAccountSku with Get-AcceptedDomain as the method to determine what tenant name is in use, and which SPO admin URL the script should attempt to connect to.

Previous cmdlet can cause wrong detections on some tenants/SKU types.