### PR TITLE
Remove client secret when Graph test is complete

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -137,7 +137,7 @@ function Get-SharePointAdminUrl
     return $url
 }
 
-Function Reset-AppSecret {
+Function Reset-SOAAppSecret {
     <#
     
         This function creates a new secret for the application
@@ -156,7 +156,7 @@ Function Reset-AppSecret {
     Return $clientsecret.Value
 }
 
-function Remove-AppSecret {
+function Remove-SOAAppSecret {
     # Removes any client secrets associated with the application
     param ($app)
 
@@ -1959,7 +1959,7 @@ Function Install-SOAPrerequisites
             }
 
             # Reset secret
-            $clientsecret = Reset-AppSecret -App $AzureADApp
+            $clientsecret = Reset-SOAAppSecret -App $AzureADApp
 
             $AppTest = Test-SOAApplication -App $AzureADApp -Secret $clientsecret -TenantDomain $tenantdomain -O365EnvironmentName $O365EnvironmentName -WriteHost
                 
@@ -2001,7 +2001,7 @@ Function Install-SOAPrerequisites
             $CheckResults += Invoke-GraphTest -AzureADApp $AzureADApp -Secret $clientsecret -TenantDomain $tenantdomain -O365EnvironmentName $O365EnvironmentName
 
             # Remove client secret
-            Remove-AppSecret -app $AzureADApp
+            Remove-SOAAppSecret -app $AzureADApp
         } 
         Else 
         {

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1958,8 +1958,8 @@ Function Install-SOAPrerequisites
 
             # Reset secret
             $clientsecret = Reset-SOAAppSecret -App $AzureADApp -Task "Prereq"
-            Write-Host "$(Get-Date) Sleeping for 30 seconds to allow for replication of the application's new client secret..."
-            Start-Sleep 30
+            Write-Host "$(Get-Date) Sleeping to allow for replication of the application's new client secret..."
+            Start-Sleep 10
 
             $AppTest = Test-SOAApplication -App $AzureADApp -Secret $clientsecret -TenantDomain $tenantdomain -O365EnvironmentName $O365EnvironmentName -WriteHost
                 

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -150,9 +150,6 @@ Function Reset-SOAAppSecret {
 
     # Provision a short lived credential +48 hrs.
     $clientsecret = New-AzureADApplicationPasswordCredential -ObjectId $App.ObjectId -EndDate (Get-Date).AddDays(2) -CustomKeyIdentifier "$Task on $(Get-Date -Format "dd-MMM-yyyy")"
-       
-    Write-Host "$(Get-Date) Sleeping for 30 seconds to allow for replication of the application's new client secret..."
-    Start-Sleep 30
 
     Return $clientsecret.Value
 }
@@ -1961,6 +1958,8 @@ Function Install-SOAPrerequisites
 
             # Reset secret
             $clientsecret = Reset-SOAAppSecret -App $AzureADApp -Task "Prereq"
+            Write-Host "$(Get-Date) Sleeping for 30 seconds to allow for replication of the application's new client secret..."
+            Start-Sleep 30
 
             $AppTest = Test-SOAApplication -App $AzureADApp -Secret $clientsecret -TenantDomain $tenantdomain -O365EnvironmentName $O365EnvironmentName -WriteHost
                 

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -144,11 +144,12 @@ Function Reset-SOAAppSecret {
     
     #>
     Param (
-        $App
+        $App,
+        $Task
     )
 
     # Provision a short lived credential +48 hrs.
-    $clientsecret = New-AzureADApplicationPasswordCredential -ObjectId $App.ObjectId -EndDate (Get-Date).AddDays(2) -CustomKeyIdentifier "Prereq on $(Get-Date -Format "dd-MMM-yyyy")"
+    $clientsecret = New-AzureADApplicationPasswordCredential -ObjectId $App.ObjectId -EndDate (Get-Date).AddDays(2) -CustomKeyIdentifier "$Task on $(Get-Date -Format "dd-MMM-yyyy")"
        
     Write-Host "$(Get-Date) Sleeping for 30 seconds to allow for replication of the application's new client secret..."
     Start-Sleep 30
@@ -1959,7 +1960,7 @@ Function Install-SOAPrerequisites
             }
 
             # Reset secret
-            $clientsecret = Reset-SOAAppSecret -App $AzureADApp
+            $clientsecret = Reset-SOAAppSecret -App $AzureADApp -Task "Prereq"
 
             $AppTest = Test-SOAApplication -App $AzureADApp -Secret $clientsecret -TenantDomain $tenantdomain -O365EnvironmentName $O365EnvironmentName -WriteHost
                 

--- a/SOA.psd1
+++ b/SOA.psd1
@@ -87,7 +87,7 @@ PowerShellVersion = '5.1'
 NestedModules = @("SOA-Prerequisites.psm1","SOA-ImportExport.psm1")
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @("Install-SOAPrerequisites","Test-SOAApplication","Invoke-SOAVersionCheck","Export-SOARPS","Invoke-WinRMBasicCheck","Get-LicenseStatus","Import-MSAL","Get-MSALAccessToken")
+FunctionsToExport = @("Install-SOAPrerequisites","Test-SOAApplication","Invoke-SOAVersionCheck","Export-SOARPS","Invoke-WinRMBasicCheck","Get-LicenseStatus","Import-MSAL","Get-MSALAccessToken","Reset-SOAAppSecret","Remove-SOAAppSecret")
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
When testing Graph is complete, any client secrets for the AAD app are removed.