### PR TITLE
Add Graph permission for Incidents to the AAD App

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1063,11 +1063,11 @@ Function Invoke-SOAModuleCheck {
             $RequiredModules += "Microsoft.PowerApps.Administration.PowerShell"
         }
     }
-    If($Bypass -notcontains "ActiveDirectory") { $RequiredModules += "ActiveDirectory" }
     If($Bypass -notcontains "Graph") {
         $RequiredModules += "Microsoft.Graph.Authentication"
         $RequiredModules += "Microsoft.Graph.Security"
     }
+    If($Bypass -notcontains "ActiveDirectory") { $RequiredModules += "ActiveDirectory" }
 
     $ModuleCheckResult = @()
 
@@ -1441,14 +1441,15 @@ Function Get-RequiredAppPermissions {
         Name="Policy.Read.All"
         Resource="00000003-0000-0000-c000-000000000000" # Graph
     }
-
-
-    if ($HasATPP2License -eq $true) {
-        $AppRoles += New-Object -TypeName PSObject -Property @{
-            ID="45cc0394-e837-488b-a098-1918f48d186c"
-            Name="SecurityIncident.Read.All"
-            Resource="00000003-0000-0000-c000-000000000000" # Graph
-        }
+    $AppRoles += New-Object -TypeName PSObject -Property @{
+        ID="45cc0394-e837-488b-a098-1918f48d186c"
+        Name="SecurityIncident.Read.All"
+        Resource="00000003-0000-0000-c000-000000000000" # Graph
+    }
+    $AppRoles += New-Object -TypeName PSObject -Property @{
+        ID="a9790345-4595-42e4-971a-ccdc79f19b7c"
+        Name="Incident.Read.All"
+        Resource="8ee8fdad-f234-4243-8f3b-15c294843740" # Microsoft Threat Protection
     }
 
     Return $AppRoles

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1439,22 +1439,13 @@ Function Get-RequiredAppPermissions {
         Resource="00000003-0000-0000-c000-000000000000" # Graph
     }
 
-    #Defender API and threat investigations not currently available in sovereign clouds, only Commercial. Update if/as endpoints become available.
-    $DefenderAvailable = $false
-    switch ($O365EnvironmentName) {
-        "Commercial"   {$DefenderAvailable=$true;break}
-        "USGovGCCHigh" {$DefenderAvailable=$false;break}
-        "USGovDoD"     {$DefenderAvailable=$false;break}
-        "Germany"      {$DefenderAvailable=$false;break}
-        "China"        {$DefenderAvailable=$false}
-    }
 
-    if ($HasATPP2License -eq $true -and $DefenderAvailable -eq $true) {
+    if ($HasATPP2License -eq $true) {
         $AppRoles += New-Object -TypeName PSObject -Property @{
-            ID="a9790345-4595-42e4-971a-ccdc79f19b7c"
-            Name="Incident.Read.All"
-            Resource="8ee8fdad-f234-4243-8f3b-15c294843740" # Microsoft Threat Protection
-        }  
+            ID="45cc0394-e837-488b-a098-1918f48d186c"
+            Name="SecurityIncident.Read.All"
+            Resource="00000003-0000-0000-c000-000000000000" # Graph
+        }
     }
 
     Return $AppRoles


### PR DESCRIPTION
Migrating to collecting Incidents using the Graph API instead of the previous Defender API.

Also adding initial support for the Microsoft Graph PowerShell SDK modules, and verifies that they are installed as part of pre-reqs