### PR TITLE
Fix to allow skipping AD module

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1682,7 +1682,7 @@ Function Install-SOAPrerequisites
     [Parameter(ParameterSetName='Default')]
     [Parameter(ParameterSetName='ConnectOnly')]
     [Parameter(ParameterSetName='ModulesOnly')]
-        [ValidateSet("AAD","MSOL","EXO","SCC","SPO","PP","Teams","Graph")][string[]]$Bypass,
+        [ValidateSet("AAD","MSOL","EXO","SCC","SPO","PP","Teams","Graph","ActiveDirectory")][string[]]$Bypass,
         [Switch]$UseProxy,
         [Parameter(DontShow)][Switch]$AllowMultipleWindows,
         [Parameter(DontShow)][switch]$NoVersionCheck,


### PR DESCRIPTION
Running `Install-SOAPrerequisites -SkipADModule` results in an error message to screen that "The variable cannot be validated because the value is not valid for the Bypass variable"