### PR TITLE
Fix for wrong connection to Graph

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -2050,7 +2050,7 @@ Function Install-SOAPrerequisites
             "China"        {$cloud = 'China'}            
         }
         if ((Get-MgContext).Scopes -notcontains 'Application.ReadWrite.All') {
-            Connect-MgGraph -Scopes 'Application.ReadWrite.All' -Environment $cloud
+            Connect-MgGraph -Scopes 'Application.ReadWrite.All' -Environment $cloud -ContextScope "Process"
         }
         
         Import-MSAL


### PR DESCRIPTION
Ensure that Graph authentication is always prompted to avoid connecting to the wrong tenant using Connect-MgGraph