### PR TITLE
Remove Graph Security SDK module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The latest version of the following modules are installed:
 * Power Apps admin
 * From the Microsoft Graph PowerShell SDK: 
    * Microsoft.Graph.Authentication
-   * Microsoft.Graph.Security
    * Microsoft.Graph.Applications
 * Active Directory
 

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1072,7 +1072,6 @@ Function Invoke-SOAModuleCheck {
     }
     If($Bypass -notcontains "Graph") {
         $RequiredModules += "Microsoft.Graph.Authentication"
-        $RequiredModules += "Microsoft.Graph.Security"
         $RequiredModules += "Microsoft.Graph.Applications"
     }
     If($Bypass -notcontains "ActiveDirectory") { $RequiredModules += "ActiveDirectory" }
@@ -2158,7 +2157,7 @@ Function Install-SOAPrerequisites
                     Pass=$True
                 }
 
-                if (Get-MgSecuritySecureScore -Top 1) {
+                if (Get-MgApplication -Top 1) {
                     $CheckResults += New-Object -Type PSObject -Property @{
                         Check="Graph SDK Command"
                         Pass=$True


### PR DESCRIPTION
Collect defender incidents from direct Graph call. Remove the requirement for Microsoft.Graph.Security module during pre-reqs installation