### PR TITLE
Add MaximumVersion param for Graph modules

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -726,7 +726,11 @@ Function Get-ModuleStatus {
     }
 
     # Check version in PS Gallery
-    $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue)
+    If ($ModuleName -Like "Microsoft.Graph.*") { # Avoid immediately upgrading to the Graph SDK 2.0 modules once they release
+        $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue -MaximumVersion 1.99)
+    } Else {
+        $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue)
+    }
     If($PSGalleryModule.Count -eq 1) {
         [version]$GalleryVersion = $PSGalleryModule.Version
         If($GalleryVersion -gt $InstalledModule.Version) {


### PR DESCRIPTION
Avoid immediately upgrading to the Graph SDK 2.0 modules once they release due to breaking changes between 1.x and 2.x

https://github.com/microsoftgraph/msgraph-sdk-powershell#upgrading-to-v2