### PR TITLE
Update pre-req to support Graph SDK v2

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -736,7 +736,12 @@ Function Get-ModuleStatus {
     }
 
     # Check version in PS Gallery
-    $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue)
+    # Control whether 1.x or 2.x of Graph SDK modules are installed
+    If ($UseNewSDK -eq $False -and $ModuleName -Like "Microsoft.Graph.*") {
+        $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue -MaximumVersion 1.99)
+    } Else {
+        $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue)
+    }
 
     If($PSGalleryModule.Count -eq 1) {
         [version]$GalleryVersion = $PSGalleryModule.Version
@@ -880,7 +885,12 @@ Function Install-ModuleFromGallery {
         $Scope = "CurrentUser"
     }
 
-    Install-Module $Module -Force -Scope:$Scope -AllowClobber
+    # Control whether 1.x or 2.x of Graph SDK modules are installed
+    If ($UseNewSDK -eq $False -and $Module -Like "Microsoft.Graph.*") {
+        Install-Module $Module -Force -Scope:$Scope -AllowClobber -MaximumVersion 1.99
+    } Else {
+        Install-Module $Module -Force -Scope:$Scope -AllowClobber
+    }
 
     If($Update) {
         # Remove old versions of the module
@@ -1723,7 +1733,10 @@ Function Install-SOAPrerequisites
     [Parameter(ParameterSetName='ModulesOnly')]
         [Switch]$ADModuleOnly,
     [Parameter(ParameterSetName='AzureADAppOnly')]
-        [Switch]$AzureADAppOnly
+        [Switch]$AzureADAppOnly,
+    [Parameter(ParameterSetName='Default')]
+    [Parameter(ParameterSetName='ModulesOnly')]
+        [Switch]$UseNewSDK
     )
 
     <#

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -250,7 +250,7 @@ Function Get-MSALAccessToken {
 
     Write-Verbose "$(Get-Date) Get-MSALAccessToken function called from the pre-reqs module - Tenant: $TenantName ClientID: $ClientID Resource: $Resource SecretLength: $($Secret.Length) O365EnvironmentName: $O365EnvironmentName"
 
-    $ccApp = [Microsoft.Identity.Client.ConfidentialClientApplicationBuilder]::Create($ClientID).WithClientSecret($Secret).WithAuthority($Authority).Build()
+    $ccApp = [Microsoft.Identity.Client.ConfidentialClientApplicationBuilder]::Create($ClientID).WithClientSecret($Secret).WithAuthority($Authority).WithLegacyCacheCompatibility($false).Build()
 
     $Scopes = New-Object System.Collections.Generic.List[string]
     $Scopes.Add("$($Resource)/.default")


### PR DESCRIPTION
There are breaking changes between the previous 1.x and new 2.x builds of the Graph SDK modules. Updating the pre-reqs to support the new ClientSecretCredential method within the SDK.