### PR TITLE
Add DirSync app scope to prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The permission scope of this application is limited to the following:
 * **Directory.Read.All** (Retrieve sign-in activity for user and guest accounts. Both this scope and the previous scope are required in order to get sign-in activity.)
 * **Policy.Read.All** (Retrieve Azure AD authorization and conditional access policies.)
 * **SecurityIncident.Read.All** (Retrieve Defender security incidents.)
+* **OnPremDirectorySynchronization.Read.All** (Retrieve Azure AD directory synchronization settings.)
 #### Dynamics CRM API:
 * **user_impersonation** (Retrieve Dataverse settings.)
 

--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1515,6 +1515,14 @@ Function Get-RequiredAppPermissions {
         Type='Scope'
         Resource="00000007-0000-0000-c000-000000000000" # Dynamics 365
     }
+    If ($O365EnvironmentName -ne "USGovGCCHigh" -and $O365EnvironmentName -ne "USGovDoD"){
+        $AppRoles += New-Object -TypeName PSObject -Property @{
+            ID="bb70e231-92dc-4729-aff5-697b3f04be95"
+            Name="OnPremDirectorySynchronization.Read.All"
+            Type='Role'
+            Resource="00000003-0000-0000-c000-000000000000" # Graph 
+        }
+    }
     Return $AppRoles
 }
 


### PR DESCRIPTION
Adding the _OnPremDirectorySynchronization.Read.All_ application permission to the app so that we can collect Azure AD directory synchronization settings.