### PR TITLE
Remove switch to install 2.x Graph modules

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -736,12 +736,7 @@ Function Get-ModuleStatus {
     }
 
     # Check version in PS Gallery
-    # Control whether 1.x or 2.x of Graph SDK modules are installed
-    If ($UseNewSDK -eq $False -and $ModuleName -Like "Microsoft.Graph.*") {
-        $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue -MaximumVersion 1.99)
-    } Else {
-        $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue)
-    }
+    $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue)
 
     If($PSGalleryModule.Count -eq 1) {
         [version]$GalleryVersion = $PSGalleryModule.Version
@@ -885,12 +880,7 @@ Function Install-ModuleFromGallery {
         $Scope = "CurrentUser"
     }
 
-    # Control whether 1.x or 2.x of Graph SDK modules are installed
-    If ($UseNewSDK -eq $False -and $Module -Like "Microsoft.Graph.*") {
-        Install-Module $Module -Force -Scope:$Scope -AllowClobber -MaximumVersion 1.99
-    } Else {
-        Install-Module $Module -Force -Scope:$Scope -AllowClobber
-    }
+    Install-Module $Module -Force -Scope:$Scope -AllowClobber
 
     If($Update) {
         # Remove old versions of the module
@@ -1732,11 +1722,7 @@ Function Install-SOAPrerequisites
     [Parameter(ParameterSetName='ModulesOnly')]
         [Switch]$ADModuleOnly,
     [Parameter(ParameterSetName='AzureADAppOnly')]
-        [Switch]$AzureADAppOnly,
-    [Parameter(ParameterSetName='Default')]
-    [Parameter(ParameterSetName='AzureADAppOnly')]
-    [Parameter(ParameterSetName='ModulesOnly')]
-        [Switch]$UseNewSDK
+        [Switch]$AzureADAppOnly
     )
 
     <#
@@ -2100,21 +2086,19 @@ Function Install-SOAPrerequisites
             Start-Sleep 10
 
             # Reconnect with Application permissions
-            If ($UseNewSDK){
-                Disconnect-MgGraph | Out-Null
-                $SSCred = $clientsecret | ConvertTo-SecureString -AsPlainText -Force
-                $GraphCred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ($AzureADApp.AppId), $SSCred
-                $ConnCount = 0
-                Do {
-                    Try {
-                        $ConnCount++
-                        Write-Verbose "$(Get-Date) Graph connection attempt #$ConnCount"
-                        Connect-MgGraph -TenantId $tenantdomain -ClientSecretCredential $GraphCred -Environment $cloud -ContextScope "Process" -ErrorAction Stop
-                    } Catch {
-                        Start-Sleep 5
-                    }
-                } Until ($null -ne (Get-MgContext))
-            }
+            Disconnect-MgGraph | Out-Null
+            $SSCred = $clientsecret | ConvertTo-SecureString -AsPlainText -Force
+            $GraphCred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ($AzureADApp.AppId), $SSCred
+            $ConnCount = 0
+            Do {
+                Try {
+                    $ConnCount++
+                    Write-Verbose "$(Get-Date) Graph connection attempt #$ConnCount"
+                    Connect-MgGraph -TenantId $tenantdomain -ClientSecretCredential $GraphCred -Environment $cloud -ContextScope "Process" -ErrorAction Stop
+                } Catch {
+                    Start-Sleep 5
+                }
+            } Until ($null -ne (Get-MgContext))
 
             $AppTest = Test-SOAApplication -App $AzureADApp -Secret $clientsecret -TenantDomain $tenantdomain -O365EnvironmentName $O365EnvironmentName -WriteHost
                 
@@ -2166,14 +2150,9 @@ Function Install-SOAPrerequisites
                 "China"        {$Resource = "https://microsoftgraph.chinacloudapi.cn"}
             }
 
-            $Token = Get-MSALAccessToken -TenantName $tenantdomain -ClientID $AzureADApp.AppId -Secret $clientsecret -Resource $Resource -O365EnvironmentName $O365EnvironmentName 
+            $MgToken = Get-MSALAccessToken -TenantName $tenantdomain -ClientID $AzureADApp.AppId -Secret $clientsecret -Resource $Resource -O365EnvironmentName $O365EnvironmentName | ConvertTo-SecureString -AsPlainText -Force
 
             Import-PSModule -ModuleName Microsoft.Graph.Authentication -Implicit $UseImplicitLoading
-            If ($UseNewSDK -eq $true) {
-                $MgToken = $Token.AccessToken | ConvertTo-SecureString -AsPlainText -Force
-            } Else {
-                $MgToken = $Token.AccessToken
-            }
             switch ($O365EnvironmentName) {
                 "Commercial"   {Connect-MgGraph -AccessToken $MgToken -ErrorAction:SilentlyContinue -ErrorVariable ConnectError | Out-Null;break}
                 "USGovGCC"     {Connect-MgGraph -AccessToken $MgToken -ErrorAction:SilentlyContinue -ErrorVariable ConnectError | Out-Null;break}


### PR DESCRIPTION
Remove the switch which controlled whether 1.x or 2.x versions of the Graph SDK modules were installed, and instead always update to the latest version of these modules.