### PR TITLE
Update token handling during SDK connection check

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -2150,7 +2150,7 @@ Function Install-SOAPrerequisites
                 "China"        {$Resource = "https://microsoftgraph.chinacloudapi.cn"}
             }
 
-            $MgToken = Get-MSALAccessToken -TenantName $tenantdomain -ClientID $AzureADApp.AppId -Secret $clientsecret -Resource $Resource -O365EnvironmentName $O365EnvironmentName | ConvertTo-SecureString -AsPlainText -Force
+            $MgToken = (Get-MSALAccessToken -TenantName $tenantdomain -ClientID $AzureADApp.AppId -Secret $clientsecret -Resource $Resource -O365EnvironmentName $O365EnvironmentName).AccessToken | ConvertTo-SecureString -AsPlainText -Force
 
             Import-PSModule -ModuleName Microsoft.Graph.Authentication -Implicit $UseImplicitLoading
             switch ($O365EnvironmentName) {


### PR DESCRIPTION
Fix a bug that the 'Graph SDK Connection' check always returns a False result, due to the way access tokens are handled in the new 2.x SDK modules.