### PR TITLE
Add role GUIDs for sovereign environments

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -1527,8 +1527,13 @@ Function Get-RequiredAppPermissions {
         Type='Role'
         Resource="00000003-0000-0000-c000-000000000000" # Graph
     }
+    switch ($O365EnvironmentName) {
+        "USGovGCCHigh" {$EnvironmentRoleID = "73d442ea-eff8-40b5-a216-87616d77e983";break}
+        "USGovDoD"     {$EnvironmentRoleID = "73d442ea-eff8-40b5-a216-87616d77e983";break}
+        Default        {$EnvironmentRoleID = "45cc0394-e837-488b-a098-1918f48d186c"}
+    }
     $AppRoles += New-Object -TypeName PSObject -Property @{
-        ID="45cc0394-e837-488b-a098-1918f48d186c"
+        ID=$EnvironmentRoleID
         Name="SecurityIncident.Read.All"
         Type='Role'
         Resource="00000003-0000-0000-c000-000000000000" # Graph


### PR DESCRIPTION
GCC-High and DoD have a different GUID for the application role SecurityIncident.Read.All compared with other tenant types (e.g. Commercial)