### PR TITLE
Add SOA consent page

### DIFF
--- a/SOA-Prerequisites.psm1
+++ b/SOA-Prerequisites.psm1
@@ -641,8 +641,7 @@ Function Invoke-Consent {
         "China"        {$AuthLocBase = "https://login.partner.microsoftonline.cn"}
     }
     # Need to use the Application ID, not Object ID
-    $Location = "$AuthLocBase/common/adminconsent?client_id=$($App.AppId)&state=12345&redirect_uri=https://soaconsentreturn.azurewebsites.net"
-    
+    $Location = "$AuthLocBase/common/adminconsent?client_id=$($App.AppId)&state=12345&redirect_uri=https://o365soa.github.io/soa/"
     Write-Important
     Write-Host "In 10 seconds, a page in the default browser will load and ask you to grant consent to Security Optimization Assessment."
     write-Host "You must sign in with an account that has Global Administrator or Privileged Role Administrator role."
@@ -677,9 +676,9 @@ Function Install-AzureADApp {
 
     # Create the Entra application
     Write-Verbose "$(Get-Date) Install-AzureADPApp Installing App"
-    #$AzureADApp = New-AzureADApplication -DisplayName "Office 365 Security Optimization Assessment"  -ReplyUrls @("https://security.optimization.assessment.local","https://soaconsentreturn.azurewebsites.net")
+    #$AzureADApp = New-AzureADApplication -DisplayName "Office 365 Security Optimization Assessment"  -ReplyUrls @("https://security.optimization.assessment.local","https://o365soa.github.io/soa")
     $AzureADApp = New-MgApplication -DisplayName "Office 365 Security Optimization Assessment" `
-        -Web @{'RedirectUris'=@("https://security.optimization.assessment.local","https://soaconsentreturn.azurewebsites.net")} `
+        -Web @{'RedirectUris'=@("https://security.optimization.assessment.local","https://o365soa.github.io/soa")} `
         -PublicClient @{'RedirectUris'='https://login.microsoftonline.com/common/oauth2/nativeclient'} `
         -SignInAudience AzureADMyOrg
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
         <div class="p-5 text-center bg-body-tertiary border rounded-3 bg-success-subtle">
           <h1 class="text-body-emphasis">Admin consent complete</h1>
           <p class="lead">
-            Granting permissions to the App is completed. You can close this window.
+            Admin consent has been successfully granted to the SOA enterprise application. You can close this window.
           </p>
           <svg class="bi mt-5 mb-3" width="48" height="48"><use xlink:href="#check2-circle"/></svg>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>SOA Consent</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  </head>
+  <body>
+    <svg xmlns="http://www.w3.org/2000/svg" class="d-none">
+      <symbol id="check2-circle" viewBox="0 0 16 16">
+        <path d="M2.5 8a5.5 5.5 0 0 1 8.25-4.764.5.5 0 0 0 .5-.866A6.5 6.5 0 1 0 14.5 8a.5.5 0 0 0-1 0 5.5 5.5 0 1 1-11 0z"/>
+        <path d="M15.354 3.354a.5.5 0 0 0-.708-.708L8 9.293 5.354 6.646a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0l7-7z"/>
+      </symbol>
+    </svg>
+    <div class="container my-5">
+        <div class="p-5 text-center bg-body-tertiary border rounded-3 bg-success-subtle">
+          <h1 class="text-body-emphasis">Admin consent complete</h1>
+          <p class="lead">
+            Granting permissions to the App is completed. You can close this window.
+          </p>
+          <svg class="bi mt-5 mb-3" width="48" height="48"><use xlink:href="#check2-circle"/></svg>
+        </div>
+      </div>
+  </body>
+</html>


### PR DESCRIPTION
Add static consent page used once the application registration and admin consent is completed. Hosted in the /docs/ folder so that it can be used along with GitHub Pages feature.