### PR TITLE
Add missing scope for prereqs installation

### DIFF
--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -847,6 +847,9 @@ function Get-LicenseStatus {
             # SKUs that start with strings include MDE to be able to use its advanced hunting API
             $targetSkus = @('DEFENDER_ENDPOINT','IDENTITY','M365_G3_R','M365_G5_GCC','M365_S','M365EDU_A3_STUD','M365EDU_A3_F''M365EDU_A5_STUD','M365EDU_A5_F','MDATP','Microsoft 365 A3 Suite','Microsoft_365_E','Microsoft_D','Microsoft_Teams_Rooms_Pro_F','Microsoft_Teams_Rooms_Pro_G','O365_w/o Teams Bundle_M','O365_w/o_Teams_Bundle_M','SPE_','WIN_','WIN10_ENT_A5','WIN10_VDA_E5','WINE5_G')
         }
+        AADP2 {
+            $targetSkus = @('AAD_PREMIUM_P2','DEVELOPERPACK_E5','EMSPREMIUM','IDENTITY_THREAT_PROTECTION','M365_G5','M365_SEC','M365EDU_A5','Microsoft_365_E5','SPE_E5','SPE_F5')
+        }
         default {
             Write-Error -Message "$(Get-Date) Invalid license type specified"
             return $false


### PR DESCRIPTION
Added Organization.Read.All as a delegated scope (and removed User.Read because Organization.Read.All includes what is needed by User.Read for the installation). Added Entra P2 to the license check. Updated the README to include the delegated scopes.