### PR TITLE
Add MDI role to application permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Graph|Policy.Read.All|Application|Get various Microsoft Entra policies, such as 
 |Graph|RoleManagement.Read.All|Application|Get Privileged Identity Management roles assigned to users, if applicable.|
 |Graph|SecurityEvents.Read.All|Application|Get active security events within your tenant.
 |Graph|SecurityIncident.Read.All|Application|Get Defender security incidents.
+|Graph|SecurityIdentitiesHealth.Read.All|Application|For organisations with Microsoft Defender for Identity, get health alerts.|
 |Dynamics CRM|user_impersonation|Delegated|Get Dataverse settings.|
 |Windows Defender ATP|AdvancedQuery.Read.All|Application|For organisations with Microsoft Defender for Endpoint, get health alerts.|
 

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -639,7 +639,7 @@ Function Invoke-Consent {
     # Need to use the Application ID, not Object ID
     $Location = "$AuthLocBase/common/adminconsent?client_id=$($App.AppId)&state=12345&redirect_uri=https://o365soa.github.io/soa/"
     Write-Important
-    Write-Host "In 10 seconds, a page in the default browser will load and ask you to grant consent to Security Optimization Assessment."
+    Write-Host "In 10 seconds, a page in the default browser will load and ask you to grant consent to Microsoft Security Assessment."
     write-Host "You must sign in with an account that has Global Administrator or Privileged Role Administrator role."
     Write-Host "After granting consent, a green OK message will appear; you can then close the browser page."
     Write-Host ""

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -847,6 +847,10 @@ function Get-LicenseStatus {
             # SKUs that start with strings include MDE to be able to use its advanced hunting API
             $targetSkus = @('DEFENDER_ENDPOINT','IDENTITY','M365_G3_R','M365_G5_GCC','M365_S','M365EDU_A3_STUD','M365EDU_A3_F''M365EDU_A5_STUD','M365EDU_A5_F','MDATP','Microsoft 365 A3 Suite','Microsoft_365_E','Microsoft_D','Microsoft_Teams_Rooms_Pro_F','Microsoft_Teams_Rooms_Pro_G','O365_w/o Teams Bundle_M','O365_w/o_Teams_Bundle_M','SPE_','WIN_','WIN10_ENT_A5','WIN10_VDA_E5','WINE5_G')
         }
+        MDI {
+            # SKUs that start with strings include MDI
+            $targetSkus = @('EMSPREMIUM','SPE_E5','SPE_F5','M365EDU_A5','IDENTITY_THREAT_PROTECTION','M365_SECURITY_COMPLIANCE','M365_G5','Microsoft_365_E5','ATA')
+        }
         AADP2 {
             $targetSkus = @('AAD_PREMIUM_P2','DEVELOPERPACK_E5','EMSPREMIUM','IDENTITY_THREAT_PROTECTION','M365_G5','M365_SEC','M365EDU_A5','Microsoft_365_E5','SPE_E5','SPE_F5')
         }
@@ -1626,7 +1630,7 @@ Function Get-RequiredAppPermissions {
             ID="bb70e231-92dc-4729-aff5-697b3f04be95"
             Name="OnPremDirectorySynchronization.Read.All"
             Type='Role'
-            Resource="00000003-0000-0000-c000-000000000000" # Graph 
+            Resource="00000003-0000-0000-c000-000000000000" # Graph
         }
     }
 
@@ -1645,6 +1649,24 @@ Function Get-RequiredAppPermissions {
             Name="AdvancedQuery.Read.All"
             Type='Role'
             Resource="fc780465-2017-40d4-a0c5-307022471b92" # WindowsDefenderATP
+        }
+    }
+
+    $MDIAvailable = $false
+    switch ($CloudEnvironment) {
+        "Commercial"   {$MDIAvailable=$true;break}
+        "USGovGCCHigh" {$MDIAvailable=$true;break}
+        "USGovDoD"     {$MDIAvailable=$true;break}
+        "Germany"      {$MDIAvailable=$false;break}
+        "China"        {$MDIAvailable=$false}
+    }
+    if ($HasMDILicense -eq $true -and $MDIAvailable -eq $true) {
+        Write-Verbose "Adding Defender for Identity role to App"
+        $AppRoles += New-Object -TypeName PSObject -Property @{
+            ID="f8dcd971-5d83-4e1e-aa95-ef44611ad351"
+            Name="SecurityIdentitiesHealth.Read.All"
+            Type='Role'
+            Resource="00000003-0000-0000-c000-000000000000" # Graph
         }
     }
 
@@ -2218,6 +2240,9 @@ Function Install-SOAPrerequisites
 
             $script:MDELicensed = Get-LicenseStatus -LicenseType MDE
             Write-Verbose "$(Get-Date) Get-LicenseStatus MDE License found: $($script:MDELicensed)"
+
+            $script:MDILicensed = Get-LicenseStatus -LicenseType MDI
+            Write-Verbose "$(Get-Date) Get-LicenseStatus MDI License found: $($script:MDILicensed)"
 
             # Determine if Microsoft Entra application exists (and has public client redirect URI set), create if doesnt
             $EntraApp = Get-SOAEntraApp -CloudEnvironment $CloudEnvironment


### PR DESCRIPTION
Currently the assessment is making a direct API call to the contoso.atp.azure.com URLs to collect health information. 

This is now possible to collect using Graph calls, which requires an additional role added to the application