### PR TITLE
Remove the Graph Applications SDK module from pre-reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ The latest version of the following PowerShell modules are installed:
 * SharePoint Online
 * Microsoft Teams
 * Power Apps admin
-* From the Microsoft Graph PowerShell SDK: 
-   * Microsoft.Graph.Authentication
-   * Microsoft.Graph.Applications
+* Microsoft.Graph.Authentication from the Microsoft Graph PowerShell SDK
 * Active Directory
 
 Note: For SharePoint Online, if a non-PowerShell Gallery version of the module is installed, it is removed from the PS Module Path to prevent conflicts.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ The latest version of the following PowerShell modules are installed:
 * SharePoint Online
 * Microsoft Teams
 * Power Apps admin
-* Microsoft.Graph.Authentication from the Microsoft Graph PowerShell SDK
+* From the Microsoft Graph PowerShell SDK: 
+  * Microsoft.Graph.Authentication
+  * Microsoft.Graph.Applications
 * Active Directory
 
 Note: For SharePoint Online, if a non-PowerShell Gallery version of the module is installed, it is removed from the PS Module Path to prevent conflicts.

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -1126,6 +1126,7 @@ Function Invoke-SOAModuleCheck {
     }
     If($Bypass -notcontains "Graph") {
         $RequiredModules += "Microsoft.Graph.Authentication"
+        $RequiredModules += "Microsoft.Graph.Applications"
     }
     If($Bypass -notcontains "ActiveDirectory") { $RequiredModules += "ActiveDirectory" }
 

--- a/SOA/SOA.psd1
+++ b/SOA/SOA.psd1
@@ -72,8 +72,7 @@ NestedModules = @('SOA-Prerequisites.psm1',
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = 'Install-SOAPrerequisites', 'Test-SOAApplication', 
                'Invoke-SOAVersionCheck', 'Export-SOARPS', 'Get-LicenseStatus', 
-               'Import-MSAL', 'Get-MSALAccessToken', 'Reset-SOAAppSecret', 
-               'Remove-SOAAppSecret', 'Reset-SOAAppSecretv2', 
+               'Import-MSAL', 'Get-MSALAccessToken', 'Reset-SOAAppSecretv2', 
                'Remove-SOAAppSecretv2'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
Instead of using the wrapped cmdlets from the Microsoft.Graph.Applications module for interacting with the App Registration in the tenant, we can make these using direct API calls using the Invoke-MgGraphRequest.

Previously we needed both the Applications and Authentication modules to both be installed. Sometimes this will create errors if different versions of modules are attempted to be loaded.