### PR TITLE
Change to logic to add AH permission scope for customers with only MDO P2 licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Graph|Policy.Read.All|Application|Get various Microsoft Entra policies, such as 
 |Graph|SecurityEvents.Read.All|Application|Get active security events within your tenant.
 |Graph|SecurityIncident.Read.All|Application|Get Defender security incidents.
 |Graph|SecurityIdentitiesHealth.Read.All|Application|For organisations with Microsoft Defender for Identity, get health alerts.|
-|Graph|ThreatHunting.Read.All|Application|For organisations with Microsoft Defender for Endpoint, get health alerts.|
+|Graph|ThreatHunting.Read.All|Application|For organisations with Microsoft Defender for Office 365 P2 to get active AIR investigations, or organisations with Microsoft Defender for Endpoint to get health alerts.|
 |Dynamics CRM|user_impersonation|Delegated|Get Dataverse settings.|
 
 ### App registration security

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -347,7 +347,7 @@ Function Set-EntraAppPermission {
     $PermissionSet = $False
     $ConsentPerformed = $False
 
-    $Roles = Get-RequiredAppPermissions -CloudEnvironment $CloudEnvironment -HasMDELicense $MDELicensed
+    $Roles = Get-RequiredAppPermissions -CloudEnvironment $CloudEnvironment -HasMDELicense $MDELicensed -HasMDILicense $MDILicensed -HasATPP2License $ATPP2Licensed
 
     <#
     
@@ -424,7 +424,7 @@ Function Invoke-AppPermissionCheck
         [Switch]$NewPermission
     )
 
-    $Roles = Get-RequiredAppPermissions -CloudEnvironment $CloudEnvironment -HasMDELicense $MDELicensed
+    $Roles = Get-RequiredAppPermissions -CloudEnvironment $CloudEnvironment -HasMDELicense $MDELicensed -HasMDILicense $MDILicensed -HasATPP2License $ATPP2Licensed
 
     # In the event of a NewPermission, $MaxTime should be longer to prevent race conditions
     If($NewPermission)
@@ -527,7 +527,7 @@ Function Invoke-AppTokenRolesCheck {
         "China"        {$GraphResource = "https://microsoftgraph.chinacloudapi.cn/"}
     }
 
-    $Roles = Get-RequiredAppPermissions -CloudEnvironment $CloudEnvironment -HasMDELicense $MDELicensed
+    $Roles = Get-RequiredAppPermissions -CloudEnvironment $CloudEnvironment -HasMDELicense $MDELicensed -HasMDILicense $MDILicensed -HasATPP2License $ATPP2Licensed
 
     # For race conditions, we will wait $MaxTime seconds and Sleep interval of $SleepTime
     $MaxTime = 300
@@ -596,7 +596,7 @@ Function Invoke-AppTokenRolesCheckV2 {
         [string]$CloudEnvironment
     )
 
-    $Roles = Get-RequiredAppPermissions -CloudEnvironment $CloudEnvironment -HasMDELicense $MDELicensed
+    $Roles = Get-RequiredAppPermissions -CloudEnvironment $CloudEnvironment -HasMDELicense $MDELicensed -HasMDILicense $MDILicensed -HasATPP2License $ATPP2Licensed
 
     $ActiveScopes = (Get-MgContext).Scopes
     $MissingRoles = @()
@@ -1530,7 +1530,9 @@ Function Get-RequiredAppPermissions {
     param
     (
     [string]$CloudEnvironment="Commercial",
-    $HasMDELicense
+    $HasMDELicense,
+    $HasMDILicense,
+    $HasATPP2License
     )
 
     <#
@@ -1642,8 +1644,8 @@ Function Get-RequiredAppPermissions {
         "Germany"      {$MDEAvailable=$false;break}
         "China"        {$MDEAvailable=$false}
     }
-    if ($HasMDELicense -eq $true -and $MDEAvailable -eq $true) {
-        Write-Verbose "Adding Defender for Endpoint role to App"
+    if (($HasMDELicense -eq $true -and $MDEAvailable -eq $true) -or $HasATPP2License -eq $true) {
+        Write-Verbose "Adding role for Advanced Hunting to App"
         $AppRoles += New-Object -TypeName PSObject -Property @{
             ID="dd98c7f5-2d42-42d3-a0e4-633161547251"
             Name="ThreatHunting.Read.All"
@@ -2243,6 +2245,9 @@ Function Install-SOAPrerequisites
 
             $script:MDILicensed = Get-LicenseStatus -LicenseType MDI
             Write-Verbose "$(Get-Date) Get-LicenseStatus MDI License found: $($script:MDILicensed)"
+
+            $script:ATPP2Licensed = Get-LicenseStatus -LicenseType ATPP2
+            Write-Verbose "$(Get-Date) Get-LicenseStatus ATPP2 License found: $($script:ATPP2Licensed)"
 
             # Determine if Microsoft Entra application exists (and has public client redirect URI set), create if doesnt
             $EntraApp = Get-SOAEntraApp -CloudEnvironment $CloudEnvironment


### PR DESCRIPTION
Advanced Hunting is used by both customers with MDE or with MDO P2 licenses. Add a check to add the permission scope if only having MDO P2