### PR TITLE
Update pre-reqs to use correct Graph object for command validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If directory synchronisation is used, a script will need to be executed on a dom
 ### Running the prerequisites script
 
 1. Open a new PowerShell window (not the ISE).
-2. Run the following to install the latest version of the SOA module from Powershell Gallery:
+2. Run the following to install the latest version of the SOA module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/SOA/):
 
    `Install-Module SOA`
 


### PR DESCRIPTION
Update the pre-req check whether Graph connection and command is successful to instead use the /v1.0/organization endpoint instead of /v1.0/me

The /me endpoint does not have the appropriate delegate permission defined anywhere in the module, so this may fail in certain cases. The /organization endpoint will work with Organization.Read.All which is defined in the module.