### PR TITLE
Add SecurityEvents.Read.All role to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Graph|Policy.Read.All|Application|Get various Microsoft Entra policies, such as 
 |Graph|PrivilegedAccess.Read.AzureADGroup|Application|Get Privileged Identity Management roles assigned to groups, if applicable.
 |Graph|RoleManagement.Read.All|Application|Get Privileged Identity Management roles assigned to users, if applicable.|
 |Graph|SecurityIdentitiesHealth.Read.All|Application|For organisations with Microsoft Defender for Identity, get health alerts.|
-|Graph|SecurityEvents.Read.All|Application|For organisations with Microsoft Defender for Identity, retrieve configuration details from Secure Score that do not have an API yet available.|
-|Graph|ThreatHunting.Read.All|Application|For organisations with Microsoft Defender for Office 365 P2 to get active AIR investigations, or organisations with Microsoft Defender for Endpoint to get health alerts.|
+|Graph|SecurityEvents.Read.All|Application|For organisations with Microsoft Defender for Identity, get configuration details from Secure Score that do not have an API available yet.|
+|Graph|ThreatHunting.Read.All|Application|For organisations with Microsoft Defender for Office 365 P2, get active automated investigations. For organisations with Microsoft Defender for Endpoint, get health alerts.|
 |Dynamics CRM|user_impersonation|Delegated|Get Dataverse settings.|
 
 ### App registration security

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Graph|Policy.Read.All|Application|Get various Microsoft Entra policies, such as 
 |Graph|PrivilegedAccess.Read.AzureADGroup|Application|Get Privileged Identity Management roles assigned to groups, if applicable.
 |Graph|RoleManagement.Read.All|Application|Get Privileged Identity Management roles assigned to users, if applicable.|
 |Graph|SecurityIdentitiesHealth.Read.All|Application|For organisations with Microsoft Defender for Identity, get health alerts.|
+|Graph|SecurityEvents.Read.All|Application|For organisations with Microsoft Defender for Identity, retrieve configuration details from Secure Score that do not have an API yet available.|
 |Graph|ThreatHunting.Read.All|Application|For organisations with Microsoft Defender for Office 365 P2 to get active AIR investigations, or organisations with Microsoft Defender for Endpoint to get health alerts.|
 |Dynamics CRM|user_impersonation|Delegated|Get Dataverse settings.|
 

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -1537,6 +1537,12 @@ Function Get-RequiredAppPermissions {
             Type='Role'
             Resource="00000003-0000-0000-c000-000000000000" # Graph
         }
+        $AppRoles += New-Object -TypeName PSObject -Property @{
+            ID="bf394140-e372-4bf9-a898-299cfc7564e5"
+            Name="SecurityEvents.Read.All"
+            Type='Role'
+            Resource="00000003-0000-0000-c000-000000000000" # Graph
+        }
     }
 
     Return $AppRoles


### PR DESCRIPTION
Add the SecurityEvents.Read.All role to application so that Secure Score results can be retrieved in certain situations where there is no direct API yet available in Graph.