### PR TITLE
Update App test to support providing manual credentials

### DIFF
--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -1781,7 +1781,7 @@ Function Install-SOAPrerequisites
         [switch]$RemoveExistingEntraApp,
     [Parameter(ParameterSetName='Default')]
     [Parameter(ParameterSetName='EntraAppOnly')]
-        [switch]$ProvideApplicationSecret
+        [switch]$PromptForApplicationSecret
     )
 
     <#
@@ -1808,7 +1808,7 @@ Function Install-SOAPrerequisites
     $EntraAppCheck = $True
 
     # Default to remediate (applicable only when not using ConnectOnly)
-    if ($DoNotRemediate -eq $false -and $ProvideApplicationSecret -eq $false){
+    if ($DoNotRemediate -eq $false -and $PromptForApplicationSecret -eq $false){
         $Remediate = $true
     }
     else {
@@ -2098,7 +2098,7 @@ Function Install-SOAPrerequisites
         }
 
         $mgContext =  (Get-MgContext).Scopes
-        if ($mgContext -notcontains 'Application.ReadWrite.All' -or ($mgContext -notcontains 'Organization.Read.All' -and $mgContext -notcontains 'Directory.Read.All') -or ($ProvideApplicationSecret)) {
+        if ($mgContext -notcontains 'Application.ReadWrite.All' -or ($mgContext -notcontains 'Organization.Read.All' -and $mgContext -notcontains 'Directory.Read.All') -or ($PromptForApplicationSecret)) {
             Write-Host "$(Get-Date) Connecting to Graph with delegated authentication..."
             if ($null -ne (Get-MgContext)){Disconnect-MgGraph | Out-Null}
             $connCount = 0
@@ -2107,7 +2107,7 @@ Function Install-SOAPrerequisites
                 try {
                     $connCount++
                     Write-Verbose "$(Get-Date) Graph Delegated connection attempt #$connCount"
-                    if ($ProvideApplicationSecret) {
+                    if ($PromptForApplicationSecret) {
                         # Request read-only permissions to Graph if manually providing the client secret
                         Connect-MgGraph -Scopes 'Application.Read.All','Organization.Read.All' -Environment $cloud -ContextScope "Process" | Out-Null
                     } else {
@@ -2162,7 +2162,7 @@ Function Install-SOAPrerequisites
                 }
             }
 
-            if ($ProvideApplicationSecret -eq $True) {
+            if ($PromptForApplicationSecret -eq $True) {
                 # Prompt for the client secret needed to connect to the application
                 $SSCred = $null
 
@@ -2262,7 +2262,7 @@ Function Install-SOAPrerequisites
                     Pass=$True
                 }
 
-                if ($ProvideApplicationSecret -eq $false) {
+                if ($PromptForApplicationSecret -eq $false) {
                     # Remove client secret
                     Remove-SOAAppSecret
                 }

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -2166,17 +2166,17 @@ Function Install-SOAPrerequisites
                 # Prompt for the client secret needed to connect to the application
                 $SSCred = $null
 
-                Write-Host "$(Get-Date) At the prompt, provide a valid Client Secret to connect to the application registration"
+                Write-Host "$(Get-Date) At the prompt, provide a valid client secret for the assessment's app registration."
                 Start-Sleep -Seconds 1
                 while ($null -eq $SSCred -or $SSCred.Length -eq 0) {
                     # UserName is a required parameter for Get-Credential but it's value is not used elsewhere in the script
-                    $SSCred = (Get-Credential -Message "Enter the application Client Secret into the password field." -UserName "Microsoft Security Assessment").Password
+                    $SSCred = (Get-Credential -Message "Enter the app registration's client secret into the password field." -UserName "Microsoft Security Assessment").Password
                 }
             } else {
                 # Reset secret
                 $clientsecret = Reset-SOAAppSecret -App $EntraApp -Task "Prereq"
                 $SSCred = $clientsecret | ConvertTo-SecureString -AsPlainText -Force
-                Write-Host "$(Get-Date) Sleeping to allow for replication of the application's new client secret..."
+                Write-Host "$(Get-Date) Sleeping to allow for replication of the app registration's new client secret..."
                 Start-Sleep 10
             }
 


### PR DESCRIPTION
For customers that cannot or are unwilling to grant Delegated permissions in Graph, allow the ability to create the SOA application registration manually.

The collection script requires additional parameters to allow details normally collected by a (Delegated) Graph query to be manually provided. This also requires changes to the SOA module to allow skipping validating the app registration has been created successfully in certain scenarios.