### PR TITLE
Remove ISE block

### DIFF
--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -1825,7 +1825,7 @@ Function Install-SOAPrerequisites
     # Detect if running in ISE and abort ($psise is an automatic variable that exists only in the ISE)
     if ($psise)
         {
-        # Leaving this empty block for future use if needed 
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         }
 
     # Detect if running in PS 7


### PR DESCRIPTION
Allow Install-SOAPrerequisites to be run in the ISE. Also tweaked the Power Apps connection test so failure to import the module is detected as an error. Also updated the Graph connection test to be successful if already connected from a previous test.