### PR TITLE
Update GitHub action to use Node.js 20

### DIFF
--- a/.github/workflows/psgallery.yml
+++ b/.github/workflows/psgallery.yml
@@ -8,7 +8,7 @@ jobs:
   publish-to-gallery:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: master
     - name: Build and publish


### PR DESCRIPTION
Avoid a warning that was generated every time the GitHub action was executed since actions/checkout@v3 uses Node.js 16 and is deprecated. This updates to actions/checkout@v4 based on Node.js 20. 

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/