### PR TITLE
Add new versions and remove unsupported version

### DIFF
--- a/docs/dirsyncversion.json
+++ b/docs/dirsyncversion.json
@@ -1,7 +1,17 @@
 [
     {
-        "Version": "2.3.20.0",
+        "Version": "2.4.21.0",
         "SupportEndDate": "\/Date(1914476400000)\/",
+        "SecurityUpdate":  false
+    },
+    {
+        "Version": "2.4.18.0",
+        "SupportEndDate": "\/Date(1759993200000)\/",
+        "SecurityUpdate":  false
+    },
+    {
+        "Version": "2.3.20.0",
+        "SupportEndDate": "\/Date(1759820400000)\/",
         "SecurityUpdate":  true
     },
     {
@@ -22,11 +32,6 @@
     {
         "Version": "2.2.8.0",
         "SupportEndDate": "\/Date(1733990400000)\/",
-        "SecurityUpdate":  false
-    },
-    {
-        "Version": "2.2.1.0",
-        "SupportEndDate": "\/Date(1728630000000)\/",
         "SecurityUpdate":  false
     }
 ]


### PR DESCRIPTION
Added 2.4.18.0 and set a support end date for 2.3.20.0 to be October 7, 2025.
Added 2.4.21.0 and set a support end date for 2.4.18.0 to be October 9, 2025.
Removed 2.2.1.0 because support ended on October 11, 2024.