### PR TITLE
Add parameters required for connecting to 21Vianet

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ If the Office 365 tenant is in a sovereign cloud environment, the `-CloudEnviron
 * Use `Germany` for Microsoft Cloud Germany
 * Use `China` for Azure and Microsoft 365 operated by 21Vianet in China
 
+#### Microsoft Graph App Registration in 21Vianet
+
+The Microsoft apps necessary for Microsoft Graph connections are not automatically synced to tenants operating within 21Vianet, and the App Registration needs to be manually configured to allow delegated connections to Microsoft Graph. 
+
+1. Navigate within the Entra ID portal to Manage / App Registrations and click the 'New registration' button.
+2. Give the App an appropriate name. Leave the 'Supported account types' configured as the default value of Single tenant. Under the Redirect URI section, select 'Public client/native (mobile & desktop)' from the dropdown menu and enter the value `http://localhost`  and complete the registration of the app.
+3. Under the 'Overview' section take note of the 'Application (client) ID' value as this will need to be manually provided when connecting to Graph.
+
 ### Active Directory module
 
 If directory synchronization is used and the Active Directory module is not installed and you cannot run PowerShell as a local admin, you can skip the installation of the module by using `-SkipAdModule`. A machine with the module installed will be needed on the first day of the engagement to collect information about the AD environment. The module can be installed on a machine using `-AdModuleOnly` or manually via another method.

--- a/README.md
+++ b/README.md
@@ -88,13 +88,16 @@ If the Office 365 tenant is in a sovereign cloud environment, the `-CloudEnviron
 * Use `Germany` for Microsoft Cloud Germany
 * Use `China` for Azure and Microsoft 365 operated by 21Vianet in China
 
-#### Microsoft Graph App Registration in 21Vianet
+#### Microsoft Graph PowerShell SDK app registration in 21Vianet
 
-The Microsoft apps necessary for Microsoft Graph connections are not automatically synced to tenants operating within 21Vianet, and the App Registration needs to be manually configured to allow delegated connections to Microsoft Graph. 
+Microsoft globally registered applications, including the Graph PowerShell SDK, do not replicate to tenants operated by 21Vianet. This means an app registration must be configured to allow the SDK to connect to Microsoft Graph when using delegated authentication:
 
-1. Navigate within the Entra ID portal to Manage / App Registrations and click the 'New registration' button.
-2. Give the App an appropriate name. Leave the 'Supported account types' configured as the default value of Single tenant. Under the Redirect URI section, select 'Public client/native (mobile & desktop)' from the dropdown menu and enter the value `http://localhost`  and complete the registration of the app.
-3. Under the 'Overview' section take note of the 'Application (client) ID' value as this will need to be manually provided when connecting to Graph.
+1. In the Microsoft Entra portal, navigate to **Manage** / **App registrations** and click the **New registration** button.
+1. Give the app a desired name.
+1. Under **Supported account types**, leave the selection at the default value for a "Single tenant" application.
+1. Under **Redirect URI**, click the drop-down for "Select a platform" and select *Public client/native (mobile & desktop)*, then enter `http://localhost`.
+1. Click the **Register** button.
+1. In the application's **Overview** section, copy the "Application (client) ID" value, which will need to be provided using the `-GraphClientId` parameter when running `Install-SOAPrerequisites` and when running the collection script.
 
 ### Active Directory module
 

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -1002,7 +1002,14 @@ Function Test-Connections {
                     # User.Read is sufficient for using the organization API to get the domain for the Teams/SPO connections
                     # Using Organization.Read.All because that is the least-common scope for getting licenses in the app check
 
-                    if ($PromptForApplicationSecret) {
+                    if ($CloudEnvironment -eq "China") {
+                        # Connections to 21Vianet must have provided the ClientID and Tenant manually
+                        if ($null -eq $GraphClientId -or $null -eq $TenantName) {
+                            Exit-Script
+                            throw "$(Get-Date) Connections to Graph in 21Vianet will fail unless the Client ID and Tenant Name are manually provided. Use `-GraphClientId` and `-TenantName` parameters to provide them after the application has been manually registered in your tenant. For more information visit https://github.com/o365soa/soa."
+                        }
+                        Connect-MgGraph -Scopes 'Application.ReadWrite.All','Organization.Read.All' -Environment $cloud -ContextScope "Process" -ClientId $GraphClientId -Tenant $TenantName | Out-Null
+                    } elseif ($PromptForApplicationSecret) {
                         # Request read-only permissions to Graph if manually providing the client secret
                         Connect-MgGraph -Scopes 'Application.Read.All','Organization.Read.All' -Environment $cloud -ContextScope "Process" -NoWelcome -ErrorVariable ConnectError | Out-Null
                     } else {
@@ -2011,13 +2018,6 @@ Function Install-SOAPrerequisites
             "China"        {$cloud = 'China'}
         }
 
-        if ($CloudEnvironment -eq "China" -and ($null -eq $GraphClientId -or $null -eq $TenantName)) {
-            # Check whether the Client ID has been manually provided
-
-            Exit-Script
-            throw "$(Get-Date) Connections to Graph in 21Vianet will fail unless the Client ID and Tenant Name are manually provided. Use `-GraphClientId` and `-TenantName` parameters to provide them after the application has been manually registered in your tenant. For more information visit https://github.com/o365soa/soa."           
-        }
-
         $mgContext =  (Get-MgContext).Scopes
         if ($mgContext -notcontains 'Application.ReadWrite.All' -or ($mgContext -notcontains 'Organization.Read.All' -and $mgContext -notcontains 'Directory.Read.All') -or ($PromptForApplicationSecret)) {
             Write-Host "$(Get-Date) Connecting to Graph with delegated authentication..."
@@ -2031,6 +2031,11 @@ Function Install-SOAPrerequisites
 
                     if ($CloudEnvironment -eq "China") {
                         # Connections to 21Vianet must have provided the ClientID and Tenant manually
+                        if ($null -eq $GraphClientId -or $null -eq $TenantName) {
+                            Exit-Script
+                            throw "$(Get-Date) Connections to Graph in 21Vianet will fail unless the Client ID and Tenant Name are manually provided. Use `-GraphClientId` and `-TenantName` parameters to provide them after the application has been manually registered in your tenant. For more information visit https://github.com/o365soa/soa."
+                        }
+
                         Connect-MgGraph -Scopes 'Application.ReadWrite.All','Organization.Read.All' -Environment $cloud -ContextScope "Process" -ClientId $GraphClientId -Tenant $TenantName | Out-Null
                     } elseif ($PromptForApplicationSecret) {
                         # Request read-only permissions to Graph if manually providing the client secret

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -2013,7 +2013,6 @@ Function Install-SOAPrerequisites
 
         if ($CloudEnvironment -eq "China" -and ($null -eq $GraphClientId -or $null -eq $TenantName)) {
             # Check whether the Client ID has been manually provided
-            Write-Host "It's required to provide the Client ID"
 
             Exit-Script
             throw "$(Get-Date) Connections to Graph in 21Vianet will fail unless the Client ID and Tenant Name are manually provided. Use `-GraphClientId` and `-TenantName` parameters to provide them after the application has been manually registered in your tenant. For more information visit https://github.com/o365soa/soa."           


### PR DESCRIPTION
21Vianet does not allow a Delegated connection to Graph using the globally registered app like in Commercial tenants. This region requires that customers have an App Registration in their own tenant that the SOA pre-reqs can use to connect. 

Add a parameter which allows the Client ID of the App Registration to be manually provided. 

It also requires that a Tenant Name be provided, otherwise there will be an error when trying to use the /common/ oauth endpoint (typically at login.microsoftonline.com but will also give the same error at login.partner.microsoftonline.cn) unless the App Registration is modified to be multitenant. The preference is that the App remains single tenant only, so we must provide the Tenant Name during the Graph connection.