### PR TITLE
Add new permission to App to collect Defender for Identity sensor data

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Graph|Policy.Read.All|Application|Get various Microsoft Entra policies, such as 
 |Graph|RoleManagement.Read.All|Application|Get Privileged Identity Management roles assigned to users, if applicable.|
 |Graph|SecurityIdentitiesHealth.Read.All|Application|For organisations with Microsoft Defender for Identity, get health alerts.|
 |Graph|SecurityEvents.Read.All|Application|For organisations with Microsoft Defender for Identity, get configuration details from Secure Score that do not have an API available yet.|
+|Graph|SecurityIdentitiesSensors.Read.All|Application|For organisations with Microsoft Defender for Identity, get sensor details.|
 |Graph|ThreatHunting.Read.All|Application|For organisations with Microsoft Defender for Office 365 P2, get active automated investigations. For organisations with Microsoft Defender for Endpoint, get health alerts.|
 |Dynamics CRM|user_impersonation|Delegated|Get Dataverse settings.|
 

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -443,7 +443,6 @@ Function Invoke-Consent {
         "USGovGCC"     {$AuthLocBase = "https://login.microsoftonline.com";break}
         "USGovGCCHigh" {$AuthLocBase = "https://login.microsoftonline.us";break}
         "USGovDoD"     {$AuthLocBase = "https://login.microsoftonline.us";break}
-        "Germany"      {$AuthLocBase = "https://login.microsoftonline.de";break}
         "China"        {$AuthLocBase = "https://login.partner.microsoftonline.cn"}
     }
     # Need to use the Application ID, not Object ID
@@ -1491,7 +1490,6 @@ Function Get-RequiredAppPermissions {
         "USGovGCC"     {$MDEAvailable=$true;$THId="dd98c7f5-2d42-42d3-a0e4-633161547251";break}
         "USGovGCCHigh" {$MDEAvailable=$true;$THId="5f804853-e3b1-447b-9a8b-6d3e1257c72a";break}
         "USGovDoD"     {$MDEAvailable=$true;$THId="5f804853-e3b1-447b-9a8b-6d3e1257c72a";break}
-        "Germany"      {$MDEAvailable=$false;$THId="dd98c7f5-2d42-42d3-a0e4-633161547251";break}
         "China"        {$MDEAvailable=$false;$THId="dd98c7f5-2d42-42d3-a0e4-633161547251"}
     }
     if (($HasMDELicense -eq $true -and $MDEAvailable -eq $true) -or $HasATPP2License -eq $true) {
@@ -1510,7 +1508,6 @@ Function Get-RequiredAppPermissions {
         "USGovGCC"     {$MDIAvailable=$true;break}
         "USGovGCCHigh" {$MDIAvailable=$true;break}
         "USGovDoD"     {$MDIAvailable=$true;break}
-        "Germany"      {$MDIAvailable=$false;break}
         "China"        {$MDIAvailable=$false}
     }
     if ($HasMDILicense -eq $true -and $MDIAvailable -eq $true) {

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -1527,6 +1527,12 @@ Function Get-RequiredAppPermissions {
             Type='Role'
             Resource="00000003-0000-0000-c000-000000000000" # Graph
         }
+        $AppRoles += New-Object -TypeName PSObject -Property @{
+            ID="5f0ffea2-f474-4cf2-9834-61cda2bcea5c"
+            Name="SecurityIdentitiesSensors.Read.All"
+            Type='Role'
+            Resource="00000003-0000-0000-c000-000000000000" # Graph
+        }
     }
 
     Return $AppRoles


### PR DESCRIPTION
Listing details of Defender for Identity sensors requires a new permission to be added to the App Registration. Add the new permission for customers that have Defender for Identity and within a region that supports it.