### PR TITLE
Check if module versions should not be installed during pre-reqs

### DIFF
--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -532,7 +532,7 @@ Function Get-ModuleStatus {
     $MaxVersion = ($script:ModuleVersions | Where-Object {$_.ModuleName -eq $ModuleName}).MaximumVersion
 
     if ($MaxVersion -ne "" -and $null -ne $MaxVersion) {
-        Write-Verbose "A MaximumVersion of $MaxVersion was specified for $ModuleName. Only this version will be Installed." -Verbose
+        Write-Verbose "A MaximumVersion of $MaxVersion was specified for $ModuleName. Only this version will be Installed."
 
         # Splat the arguments when using Find-Module
         $Arguments = @{
@@ -2025,7 +2025,6 @@ Function Install-SOAPrerequisites {
     } Catch {} 
 
     if ($moduleResponse.StatusCode -eq 200) {
-        Write-Verbose "Downloading File" -Verbose
         $script:moduleVersions = $moduleResponse.Content | ConvertFrom-Json
     }
 

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -995,8 +995,6 @@ function Import-PSModule {
             Import-Module (Join-Path -Path $PAPath "Microsoft.PowerApps.AuthModule.psm1") -WarningAction:SilentlyContinue -Force
         }
         Import-Module -Name $ModuleName -RequiredVersion $highestVersion -ErrorVariable loadError -Force -WarningAction SilentlyContinue
-        $Current = (Get-Module -Name $ModuleName).Version.ToString()
-        Write-Host "Version that's currently loaded for $ModuleName is $Current"
         if ($loadError) {
             Write-Error -Message "Error loading module $ModuleName."
         }

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -526,8 +526,23 @@ Function Get-ModuleStatus {
     # Set variables used
     $MultipleFound = $False
     $Installed = $False
+    $Arguments = @{}
 
-    $InstalledModule = @(Get-Module -Name $ModuleName -ListAvailable)
+    # Evaluate the ModuleVersion JSON file to determine if any versions should be excluded
+    $MaxVersion = ($script:ModuleVersions | Where-Object {$_.ModuleName -eq $ModuleName}).MaximumVersion
+
+    if ($MaxVersion -ne "" -and $null -ne $MaxVersion) {
+        Write-Verbose "A MaximumVersion of $MaxVersion was specified for $ModuleName. Only this version will be Installed." -Verbose
+
+        # Splat the arguments when using Find-Module
+        $Arguments = @{
+            MaximumVersion = $MaxVersion
+        }
+
+        $InstalledModule = @(Get-Module -Name $ModuleName -ListAvailable | Where-Object {$_.Version -le $MaxVersion})
+    } else {
+        $InstalledModule = @(Get-Module -Name $ModuleName -ListAvailable)
+    }
 
     ForEach($M in $InstalledModule)
     {
@@ -551,7 +566,7 @@ Function Get-ModuleStatus {
         $Installed = $True
     }
 
-    $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue)
+    $PSGalleryModule = @(Find-Module $ModuleName -ErrorAction:SilentlyContinue @Arguments)
 
     If($PSGalleryModule.Count -eq 1) {
         [version]$GalleryVersion = $PSGalleryModule.Version
@@ -926,12 +941,12 @@ Function Invoke-SOAModuleCheck {
     $ConflictModules = @()
 
     # Bypass checks
-    If($Bypass -notcontains "SPO") { $RequiredModules += "Microsoft.Online.SharePoint.PowerShell" }
-    If($Bypass -notcontains "Teams") {$RequiredModules += "MicrosoftTeams"}
-    If (($Bypass -notcontains "EXO" -or $Bypass -notcontains "SCC")) {$RequiredModules += "ExchangeOnlineManagement"}
-    If ($Bypass -notcontains "PP") {$RequiredModules += "Microsoft.PowerApps.Administration.PowerShell"}
-    If($Bypass -notcontains "Graph") {$RequiredModules += "Microsoft.Graph.Authentication"}
-    If($Bypass -notcontains "ActiveDirectory") { $RequiredModules += "ActiveDirectory" }
+    if ($Bypass -notcontains "SPO") { $RequiredModules += "Microsoft.Online.SharePoint.PowerShell" }
+    if ($Bypass -notcontains "Teams") {$RequiredModules += "MicrosoftTeams"}
+    if (($Bypass -notcontains "EXO" -or $Bypass -notcontains "SCC")) {$RequiredModules += "ExchangeOnlineManagement"}
+    if ($Bypass -notcontains "PP") {$RequiredModules += "Microsoft.PowerApps.Administration.PowerShell"}
+    if ($Bypass -notcontains "Graph") {$RequiredModules += "Microsoft.Graph.Authentication"}
+    if ($Bypass -notcontains "ActiveDirectory") { $RequiredModules += "ActiveDirectory" }
 
     $ModuleCheckResult = @()
 
@@ -956,7 +971,17 @@ function Import-PSModule {
         )
 
     if ($Implicit -eq $false) {
-        $highestVersion = (Get-Module -Name $ModuleName -ListAvailable | Sort-Object -Property Version -Descending | Select-Object -First 1).Version.ToString()
+        # Evaluate the ModuleVersion JSON file to determine if any versions should be excluded
+        $MaxVersion = ($script:ModuleVersions | Where-Object {$_.ModuleName -eq $ModuleName}).MaximumVersion
+
+        if ($MaxVersion -ne "" -and $null -ne $MaxVersion) {
+            Write-Verbose "A MaximumVersion of $MaxVersion was specified for $ModuleName. Only this version will be Imported."
+
+            $highestVersion = (Get-Module -Name $ModuleName -ListAvailable | Where-Object {$_.Version -le $MaxVersion} | Sort-Object -Property Version -Descending | Select-Object -First 1).Version.ToString()
+        } else {
+            $highestVersion = (Get-Module -Name $ModuleName -ListAvailable | Sort-Object -Property Version -Descending | Select-Object -First 1).Version.ToString()
+        }
+
         # Multiple loaded versions are listed in reverse order of precedence
         $loadedModule = Get-Module -Name $ModuleName | Select-Object -Last 1
         if ($loadedModule -and $loadedModule.Version.ToString() -ne $highestVersion) {
@@ -970,6 +995,8 @@ function Import-PSModule {
             Import-Module (Join-Path -Path $PAPath "Microsoft.PowerApps.AuthModule.psm1") -WarningAction:SilentlyContinue -Force
         }
         Import-Module -Name $ModuleName -RequiredVersion $highestVersion -ErrorVariable loadError -Force -WarningAction SilentlyContinue
+        $Current = (Get-Module -Name $ModuleName).Version.ToString()
+        Write-Host "Version that's currently loaded for $ModuleName is $Current"
         if ($loadError) {
             Write-Error -Message "Error loading module $ModuleName."
         }
@@ -1015,7 +1042,7 @@ Function Test-Connections {
         $connectToGraph = $true
     }
     if ($connectToGraph -eq $true) {
-        Import-PSModule -ModuleName Microsoft.Graph.Authentication -Implicit $UseImplicitLoading
+        Import-PSModule -ModuleName Microsoft.Graph.Authentication -Implicit:$UseImplicitLoading
         switch ($CloudEnvironment) {
             "Commercial"   {$cloud = 'Global'}
             "USGovGCC"     {$cloud = 'Global'}
@@ -1091,7 +1118,7 @@ Function Test-Connections {
     
     #>
     if ($Bypass -notcontains 'SCC' -or $Bypass -notcontains 'EXO') {
-        Import-PSModule -ModuleName ExchangeOnlineManagement -Implicit $UseImplicitLoading
+        Import-PSModule -ModuleName ExchangeOnlineManagement -Implicit:$UseImplicitLoading
     }
 
     If($Bypass -notcontains "SCC") {
@@ -1200,7 +1227,7 @@ Function Test-Connections {
     
     #>
     If($Bypass -notcontains "SPO") {
-        Import-PSModule -ModuleName Microsoft.Online.SharePoint.PowerShell -Implicit $UseImplicitLoading
+        Import-PSModule -ModuleName Microsoft.Online.SharePoint.PowerShell -Implicit:$UseImplicitLoading
         # Reset vars
         $Connect = $False; $ConnectError = $Null; $Command = $False; $CommandError = $Null
 
@@ -1250,7 +1277,7 @@ Function Test-Connections {
             $TeamsLicensed = (Get-LicenseStatus -LicenseType Teams)
         }
         if ($TeamsLicensed -eq $true) {
-            Import-PSModule -ModuleName MicrosoftTeams -Implicit $UseImplicitLoading
+            Import-PSModule -ModuleName MicrosoftTeams -Implicit:$UseImplicitLoading
             # Reset vars
             $Connect = $False; $ConnectError = $Null; $Command = $False; $CommandError = $Null
 
@@ -1301,7 +1328,7 @@ Function Test-Connections {
     #>
     If($Bypass -notcontains 'PP') {
 
-        Import-PSModule -ModuleName Microsoft.PowerApps.Administration.PowerShell -Implicit $UseImplicitLoading
+        Import-PSModule -ModuleName Microsoft.PowerApps.Administration.PowerShell -Implicit:$UseImplicitLoading
         # Reset vars
         $Connect = $False; $ConnectError = $Null; $Command = $False; $CommandError = $Null
 
@@ -1992,6 +2019,16 @@ Function Install-SOAPrerequisites {
         Write-Host "Proxy requirement was not specified with UseProxy. Connection will be attempted directly."
         Write-Host ""
         $RPSProxySetting = New-PSSessionOption -ProxyAccessType None 
+    }
+
+    # Download module file to determine if any versions should be skipped. Used by both the Module and Connection checks
+    Try {
+        $moduleResponse = Invoke-WebRequest -Uri "https://o365soa.github.io/soa/moduleversion.json"
+    } Catch {} 
+
+    if ($moduleResponse.StatusCode -eq 200) {
+        Write-Verbose "Downloading File" -Verbose
+        $script:moduleVersions = $moduleResponse.Content | ConvertFrom-Json
     }
 
     <# 

--- a/docs/moduleversion.json
+++ b/docs/moduleversion.json
@@ -1,0 +1,22 @@
+[
+    {
+        "ModuleName": "Microsoft.Online.SharePoint.PowerShell",
+        "MaximumVersion": ""
+    },
+    {
+        "ModuleName": "MicrosoftTeams",
+        "MaximumVersion": ""
+    },
+    {
+        "ModuleName": "ExchangeOnlineManagement",
+        "MaximumVersion": "3.6.0"
+    },
+    {
+        "ModuleName": "Microsoft.PowerApps.Administration.PowerShell",
+        "MaximumVersion": ""
+    },
+    {
+        "ModuleName": "Microsoft.Graph.Authentication",
+        "MaximumVersion": ""
+    }
+]


### PR DESCRIPTION
Add a check to the Module and Connection check sections to evaluate if certain modules which should be "skipped" during the pre-req installation. This allows for scenarios where the latest version of a particular PowerShell module is not suitable, e.g. there is a breaking change in a module.