### PR TITLE
Limit module installation from PSGallery to MaxVersion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Settings within the .vscode directory
+.vscode/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The following Microsoft security assessments have several prerequisites that nee
 - Microsoft 365 Foundations - Workload Security Assessment
 - Security Optimization Assessment for Microsoft Defender
 
-The preqrequisites installation script is included in a PowerShell module named SOA.
+The prerequisites installation script is included in a PowerShell module named SOA.
 
 ## Prerequisites Breakdown
 
@@ -46,7 +46,7 @@ In order to install the SOA module and run the prerequisites script, you must ha
      `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
       
 ### Permissions
-* Local admin (running PowerShell as an adminisrator) is not required unless the Active Directory module needs to be installed (see [below](#active-directory-module)).
+* Local admin (running PowerShell as an administrator) is not required unless the Active Directory module needs to be installed (see [below](#active-directory-module)).
 * The user installing the prerequisites needs the following roles:
    * Application Administrator (or Cloud App Administrator or Privileged Role Administrator), to create the app registration. (If this is not possible, contact the resource delivering the assessment for instructions to manually create the app registration.)
    * Billing Administrator, to get the licenses in the tenant.

--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -744,16 +744,29 @@ Function Install-ModuleFromGallery {
         [Switch]$Update
     )
 
+    $InstallArguments = @{}
+
     # Install the module from PSGallery specifying Force
     # AllowClobber allows Teams module to be installed when SfBO module is installed/loaded
     if (Get-IsAdministrator) {
-        $Scope = "AllUsers"
+        $InstallArguments = @{
+            Scope = "AllUsers"
+        }
     }
     else {
-        $Scope = "CurrentUser"
+        $InstallArguments = @{
+            Scope = "CurrentUser"
+        }
     }
 
-    Install-Module $Module -Force -Scope:$Scope -AllowClobber
+    $MaxVersion = ($script:ModuleVersions | Where-Object {$_.ModuleName -eq $Module}).MaximumVersion
+    if ($MaxVersion) {
+        Write-Verbose "A MaximumVersion of $MaxVersion was specified for $Module. Only this version will be installed from the PSGallery."
+
+        $InstallArguments.Add("RequiredVersion",$MaxVersion)
+    }
+
+    Install-Module $Module -Force -AllowClobber @InstallArguments
 
     If($Update) {
         # Remove old versions of the module


### PR DESCRIPTION
Fixes bug where in certain scenarios, the MaxVersion would be ignored, and it would still install the latest available version from the PSGallery