### PR TITLE
Update support end dates for Entra Connect

### DIFF
--- a/docs/dirsyncversion.json
+++ b/docs/dirsyncversion.json
@@ -21,22 +21,22 @@
     },
     {
         "Version": "2.3.20.0",
-        "SupportEndDate": "\/Date(1759820400000)\/",
+        "SupportEndDate": "\/Date(1744009200819)\/",
         "SecurityUpdate":  true
     },
     {
         "Version": "2.3.8.0",
-        "SupportEndDate": "\/Date(1752649200000)\/",
+        "SupportEndDate": "\/Date(1744009200819)\/",
         "SecurityUpdate":  false
     },
     {
         "Version": "2.3.6.0",
-        "SupportEndDate": "\/Date(1743490800000)\/",
+        "SupportEndDate": "\/Date(1744009200819)\/",
         "SecurityUpdate":  false
     },
     {
         "Version": "2.3.2.0",
-        "SupportEndDate": "\/Date(1740124800000)\/",
+        "SupportEndDate": "\/Date(1744009200819)\/",
         "SecurityUpdate":  false
     }
 ]


### PR DESCRIPTION
Update end of support dates for 2.3.x versions for Entra Connect based on upcoming breaking changes