### PR TITLE
Fix connect error variable reset for Teams

### DIFF
--- a/SOA/SOA-Prerequisites.psm1
+++ b/SOA/SOA-Prerequisites.psm1
@@ -1412,7 +1412,8 @@ Function Test-Connections {
         if ($TeamsLicensed -eq $true) {
             Import-PSModule -ModuleName MicrosoftTeams -Implicit:$UseImplicitLoading
             # Reset vars
-            $Connect = $False; $ConnectError = $Null; $Command = $False; $CommandError = $Null
+            $Connect = $False; $Command = $False; $CommandError = $Null
+            Remove-Variable -Name ConnectError -ErrorAction SilentlyContinue
 
             Write-Host "$(Get-Date) Connecting to Microsoft Teams..."
             # Although the connection cmdlet supports providing an account ID, if used it will force the user to [re-]authenticate rather than presenting the account picker


### PR DESCRIPTION
Change how the variable is reset for a Teams connection error. (When an error occurs, the variable is created differently than when connecting to other workloads, so the reset of that variable needs to be handled differently.)